### PR TITLE
Refetch Boltz Rates before Confirmation

### DIFF
--- a/app/components/providers/app-state-provider.tsx
+++ b/app/components/providers/app-state-provider.tsx
@@ -55,6 +55,10 @@ export function AppStateProvider({ children }: { children: React.ReactNode }) {
   });
 
   const update = (state: Partial<AppState>) => {
+    if(state.screen === AppScreen.Confirmation && boltz) {
+      boltz.refetchRates()
+    }
+
     setValue(
       (v) =>
         ({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,8 +48,8 @@ export default async function Index() {
     <Container>
       <FixedFloatProvider currencies={currencies}>
         <BoltzProvider
-          boltzToLnRate={boltzToLnRate}
-          boltzFromLnRate={boltzFromLnRate}
+          initialBoltzToLnRate={boltzToLnRate}
+          initialBoltzFromLnRate={boltzFromLnRate}
         >
           <AppStateProvider>
             <Content />

--- a/app/screens/confirm.tsx
+++ b/app/screens/confirm.tsx
@@ -82,6 +82,7 @@ export default function ConfirmScreen() {
             from: "BTC",
             claimPublicKey: keypair.publicKey.toString("hex"),
             preimageHash: crypto.sha256(preimage).toString("hex"),
+            pairHash: boltz.boltzFromLnRate.hash,
           });
 
           boltz.setSwap({
@@ -109,6 +110,7 @@ export default function ConfirmScreen() {
             to: "BTC",
             from: "BTC",
             refundPublicKey: keypair.publicKey.toString("hex"),
+            pairHash: boltz.boltzToLnRate.hash,
           });
 
           boltz.setSwap({

--- a/app/screens/confirm.tsx
+++ b/app/screens/confirm.tsx
@@ -61,10 +61,19 @@ export default function ConfirmScreen() {
       if (coin === "BTC") {
         if (!boltz) return;
 
-        initEccLib(ecc);
-        const keypair = ECPairFactory(ecc).makeRandom();
+        const { boltzToLnRate, boltzFromLnRate } = await boltz.refetchRates();
 
         if (direction === Direction.FromLightning) {
+          if (boltzFromLnRate.hash !== boltz.boltzFromLnRate.hash) {
+            toast.show(
+              "Network fees have been updated. Please check the fees and try again.",
+            );
+            return;
+          }
+
+          initEccLib(ecc);
+          const keypair = ECPairFactory(ecc).makeRandom();
+
           const preimage = randomBytes(32);
 
           const swap = await boltzApi.createReverseSwap({
@@ -85,6 +94,16 @@ export default function ConfirmScreen() {
             screen: AppScreen.FromLnStatus,
           });
         } else {
+          if (boltzToLnRate.hash !== boltz.boltzToLnRate.hash) {
+            toast.show(
+              "Network fees have been updated. Please check the fees and try again.",
+            );
+            return;
+          }
+
+          initEccLib(ecc);
+          const keypair = ECPairFactory(ecc).makeRandom();
+
           const swap = await boltzApi.createSubmarineSwap({
             invoice: draftAddress,
             to: "BTC",


### PR DESCRIPTION
Refetches the boltz rates before you navigate to the confirmation page and when you click the "Confirm" button.

If the hash doesn't match, fees are re-calculated and the user is prompted to confirm the transaction again.
